### PR TITLE
Demonstrate command line filename argument

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -69,6 +69,11 @@ V:     B  D♯ F♯
 I:     E  G♯ B
 #+end_src
 
+It is also possible to specify a filename to write to from the command line.
+#+begin_src
+echo "I V vii I" | triads C triads.txt
+#+end_src
+
 * Building
 make dependencies available first
 #+begin_src sh


### PR DESCRIPTION
This demonstrates the command line filename argument mentioned at the beginning of the README with a shell example.
